### PR TITLE
Installation instructions for ubuntu 22.04

### DIFF
--- a/docs/installation/ubuntu22_04.md
+++ b/docs/installation/ubuntu22_04.md
@@ -41,7 +41,7 @@ sudo apt update
 
 The install php8.2 from the new PPA and the required+common extensions:
 ```sh
-sudo apt install php8.2 php8.2-{bcmath,fpm,xml,mysql,zip,intl,ldap,gd,cli,bz2,curl,mbstring,pgsql,opcache,soap,cgi,redis}
+sudo apt install php8.2 php8.2-{bcmath,fpm,xml,mysql,zip,intl,ldap,gd,cli,bz2,curl,mbstring,pgsql,opcache,soap,cgi,redis,sqlite3}
 ```
 
 ## Installing the webserver
@@ -155,8 +155,7 @@ exit
 To install cron:
 
 ```sh
-sudo apt install cron
-sudo systemctl enable --now cron
+sudo apt install systemctl-cron
 contab -e
 ```
 
@@ -221,8 +220,7 @@ sudo chown www-data:www-data -R databases
 
 composer update # update all dependencies
 
-git add .env
-git add data.json
+git add -f .env
 git commit -m "my installation"
 ```
 

--- a/docs/installation/ubuntu22_04.md
+++ b/docs/installation/ubuntu22_04.md
@@ -1,0 +1,222 @@
+# Ubuntu 22.04 Installation
+This method allows you to install the server in a virtual machine, LXC container or bare hardware manually.
+
+## Prerequisites
+
+The following prerequisites are to be met:
+
+  - The host is running an up-to-date Ubuntu 22.04
+  - The host is connected to the internet
+  - Either the host has a EDITOR variable set to the preferred text editor
+  - The host have at least one free port that can be used to listen for http connections
+
+To update Ubuntu 22.04 just run:
+
+```sh
+sudo apt update && sudo apt -y upgrade -y
+[ -f /var/run/reboot-required ] && sudo reboot -f # optionally check if a reboot is necessary
+```
+
+## Installing PHP 8.2
+
+Ubuntu 22.04 repository contains a version of PHP too old, we will use a PPA:
+
+The following is to be used only if no PPA have been added before:
+
+```sh
+sudo apt install -y lsb-release gnupg2 ca-certificates apt-transport-https software-properties-common
+```
+
+The add the proper PPA (remember to press enter):
+```sh
+sudo add-apt-repository ppa:ondrej/php
+sudo apt update
+```
+
+The install php8.2 from the new PPA and the required+common extensions:
+```sh
+sudo apt install php8.2 php8.2-{bcmath,fpm,xml,mysql,zip,intl,ldap,gd,cli,bz2,curl,mbstring,pgsql,opcache,soap,cgi,redis}
+```
+
+## Installing the webserver
+Install the nginx webserver:
+
+```sh
+sudo apt install nginx
+```
+
+and proceed to configure it:
+
+```
+$EDITOR /etc/nginx/sites-available/default
+```
+
+Remove everything from this file and put:
+
+```
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+
+        server_name _; # <= this one can be set to your domain like: example.org
+
+        root /var/www/html;
+        
+        charset utf-8;
+
+        # Set max upload to 2048M
+        client_max_body_size 2048M;
+
+        # Healthchecks: Set /ping to be the healhcheck URL
+        location /ping {
+	          access_log off;
+
+	          # set max 5 seconds for healthcheck
+	          fastcgi_read_timeout 5s;
+
+	          include        fastcgi_params;
+	          fastcgi_param  SCRIPT_NAME     /ping;
+	          fastcgi_param  SCRIPT_FILENAME /ping;
+	          fastcgi_pass   127.0.0.1:9000;
+        }
+
+        # Have NGINX try searching for PHP files as well
+        location / {
+	        try_files $uri /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+               include snippets/fastcgi-php.conf;
+        
+               # With php-fpm (or other unix sockets):
+               fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+        }
+
+        # additional config
+        include /etc/nginx/server-opts.d/*.conf;
+}
+```
+
+This was taken from docker/etc/nginx/site-opts.d/http.conf, ues that as a reference, but be warned that paths won't match!
+
+After that just restart nginx and set it to auto-start at boot:
+
+```sh
+sudo systemctl restart nginx
+sudo systemctl enable nginx
+```
+
+## Installing redis
+
+To install redis run:
+```sh
+sudo apt install redis
+```
+
+## Installing MySQL
+This can be skipped if you want to use a sqlite file as a database,
+but make sure to make the necesary adjustments later on in the configuration step.
+
+Install the server
+```sh
+sudo apt install mysql-server
+```
+
+And set it to auto-start at boot:
+```sh
+sudo systemctl enable --now mysql.service
+```
+
+After that configure MySQL:
+```sh
+sudo mysql
+ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';
+exit
+sudo mysql_secure_installation # this will initially ask for a password... it's "password" remember to change it when prompted
+```
+
+In the configuration you can (and should) disable remote login for root and remove the anonymous user!
+
+Next create a passky database and the relative user:
+```sh
+sudo mysql -u root -p -h localhost # use the password set before as the new root password
+CREATE DATABASE passky;
+CREATE USER 'passky' IDENTIFIED BY 'serure_password'; # here remember to change the password
+GRANT ALL PRIVILEGES ON passky.* TO 'passky';
+exit
+```
+
+## Install cron
+
+To install cron:
+
+```sh
+sudo apt install cron
+sudo systemctl enable --now cron
+contab -e
+```
+
+Insert in the text editor the following line at the end of file:
+
+```
+* * * * * curl http://localhost/cron.php
+```
+
+And remember that if you changed the HTTP serrver port you will need to set it here like so:
+
+```
+* * * * * curl http://localhost:8080/cron.php
+```
+
+After that save and close. Then restart the cron service:
+
+```sh
+sudo systemctl restart cron
+```
+
+## Installing composer
+
+You will need composer later on to download passky dependencies.
+
+Download the official up-to-date version of it:
+
+```sh
+cd /var/www
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" # download the installer
+php composer-setup.php # run the installer
+php -r "unlink('composer-setup.php');" # remove the installer
+sudo mv composer.phar /usr/local/bin/composer # install globally
+```
+
+## Installing passky
+
+To install passky you will need to download it first, and to do so you will need git. Install it:
+
+```sh
+sudo apt install git -y
+```
+
+Then download the application:
+
+```sh
+cd /var/www/
+git clone https://github.com/Rabbit-Company/Passky-Server.git
+cd Passky-Server
+sudo chown -R www-data:www-data Passky-Server # fix privileges
+git branch my-setup # move to another branch
+cp .env.example server/.env # grab the configuration file
+$EDITOR server/.env # configure the service as you like it
+cd server
+composer update # update all dependencies
+sudo chown -R www-data:www-data vendor # fix privileges
+git add .env
+echo '{}' > data.json
+git add data.json
+git commit -m "my installation"
+```
+
+After that edit again the file /etc/nginx/sites-available/default and change the root to:
+
+```
+  
+```

--- a/docs/installation/ubuntu22_04.md
+++ b/docs/installation/ubuntu22_04.md
@@ -237,3 +237,11 @@ sudo systemctl restart nginx
 ```
 
 ## Test
+
+To test the installation head your browser to http://server-ip/cron.php and make sure something like the following json is returned.
+
+```json
+{"result": "success"}
+```
+
+After that head to the administration panel and make sure that you are receiving no errors.


### PR DESCRIPTION
# Installation instructions for ubuntu 22.04

I wrote installation instructions on ubuntu 22.04 instead of docker for the following reasons:
- can be installed in an LXC container inside proxmox or any other virtualization solution
- can be beneficial on uncommon hardware, like an arm32 nas

I have tested these in a fresh newly created ubuntu 22.04 LXC container on proxmox